### PR TITLE
feat: added NO_IMAGE check

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -138,10 +138,12 @@ function modifyTaskDefinitionFile() {
             exit 1;
         fi
 
-        touch tmpfile;
+        if [[ "$IMAGE" != "NO_IMAGE" ]]; then
+            touch tmpfile;
 
-        # shellcheck disable=SC2002
-        cat "$TASK_DEFINITION_FILE" | jq --arg image "$IMAGE" --arg container "$CONTAINER" '(.containerDefinitions[]? | select(.name==$container)) |= (.image=$image)' > tmpfile && mv tmpfile "$TASK_DEFINITION_FILE"
+            # shellcheck disable=SC2002
+            cat "$TASK_DEFINITION_FILE" | jq --arg image "$IMAGE" --arg container "$CONTAINER" '(.containerDefinitions[]? | select(.name==$container)) |= (.image=$image)' > tmpfile && mv tmpfile "$TASK_DEFINITION_FILE"
+        fi
     done
 
     if jq < "$TASK_DEFINITION_FILE" &> /dev/null; then


### PR DESCRIPTION
Added feature to check if the image is sending a `NO_IMAGE` response to indicate there is no image.

Related to PR: https://github.com/sourcetoad/github-action-workflows/pull/12