### PR TITLE
feat: Handle missing ECS deployment gracefully when replaced by exter…

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -69,6 +69,13 @@ function pollForSpecificServiceUpdate() {
         while true; do
             RESPONSE=$(describeService)
             DEPLOYMENT=$(echo "$RESPONSE" | jq -r --arg deploymentId "$1" '.services[]?.deployments[] | select(.id==$deploymentId)')
+
+            if [ -z "$DEPLOYMENT" ]; then
+                echo -e "${ORANGE}Deployment with ID $1 could not be found. Likely replaced by a manual or external deployment.";
+                echo -e "${ORANGE}Exiting polling loop. Please verify deployment status in the AWS Console."
+                exit 0;
+            fi
+
             DESIRED_COUNT=$(echo "$DEPLOYMENT" | jq -r '.desiredCount // 0')
             RUNNING_COUNT=$(echo "$DEPLOYMENT" | jq -r '.runningCount // 0')
             PENDING_COUNT=$(echo "$DEPLOYMENT" | jq -r '.pendingCount // 0')


### PR DESCRIPTION
This PR improves the robustness of the ECS deployment polling script. Previously, if a deployment was replaced by a manual or external redeploy while the GitHub Action was polling, the script would fail or exit with unclear messaging. Now, if the deployment ID is no longer found (indicating a replacement), the script exits gracefully with a clear message.