### PR TITLE
build: correct jq checks to be valid against task def files

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -154,7 +154,7 @@ function modifyTaskDefinitionFile() {
         fi
     done
 
-    if jq < "$TASK_DEFINITION_FILE" &> /dev/null; then
+    if ! jq -e . < "$TASK_DEFINITION_FILE" >/dev/null 2>&1; then
         echo -e "${RED}Task Definition became invalid JSON after modifications (invalid_task_definition)."
 
         if [ -n "$RUNNER_DEBUG" ]; then
@@ -203,7 +203,7 @@ if [ -n "$INPUT_PREPARE_TASK_CONTAINER_IMAGE_CHANGES" ] && [ -n "$INPUT_PREPARE_
     modifyTaskDefinitionFile "$INPUT_PREPARE_TASK_DEFINITION_NAME" "$INPUT_PREPARE_TASK_CONTAINER_IMAGE_CHANGES"
 
     if [ -n "$INPUT_PREPARE_TASK_CONTAINER_NETWORK_CONFIG_FILEPATH" ]; then
-        if jq < "$INPUT_PREPARE_TASK_CONTAINER_NETWORK_CONFIG_FILEPATH" &> /dev/null; then
+        if ! jq -e . < "$INPUT_PREPARE_TASK_CONTAINER_NETWORK_CONFIG_FILEPATH" >/dev/null 2>&1; then
             echo -e "${RED}Network configuration is invalid JSON. (invalid_network_config_file)."
             exit 1;
         fi


### PR DESCRIPTION
The older logic was wrong - always passing (during a failure) and failing during a pass. It seems earlier versions of JQ had a different default mode when invoked without parameters which generated invalid json (escaped chars) which failed the check.

In modern jq the default execution no longer does that, so it works (but then fails since our logic was inverted).

I moved this to properly look at exit code `-e`.

### Testing

```
bash-3.2$ export TASK_DEFINITION_FILE=test.json 
bash-3.2$     if ! jq -e . < "$TASK_DEFINITION_FILE" >/dev/null 2>&1; then
>         echo -e "${RED}Task Definition became invalid JSON after modifications (invalid_task_definition)."
> 
>         if [ -n "$RUNNER_DEBUG" ]; then
>             echo "::debug::Debug enabled. Outputting modified Task Definition file.";
>             cat "$TASK_DEFINITION_FILE"
>         fi
> 
>         exit 1;
>     fi
bash-3.2$
```

Fixes #25 